### PR TITLE
refactor: add From/TryFrom traits for Value type conversion

### DIFF
--- a/crates/cel-core/examples/extract_values.rs
+++ b/crates/cel-core/examples/extract_values.rs
@@ -1,0 +1,81 @@
+//! Extracting Rust types from CEL Values using TryFrom.
+//!
+//! Run with: cargo run -p cel-core --example extract_values
+
+use cel_core::eval::{MapActivation, OptionalValue, Value, ValueMap};
+use cel_core::{CelType, Env};
+
+fn main() {
+    let env = Env::with_standard_library()
+        .with_variable("count", CelType::Int)
+        .with_variable("items", CelType::list(CelType::Int))
+        .with_variable("config", CelType::map(CelType::String, CelType::String));
+
+    let mut activation = MapActivation::new();
+    activation.insert("count", 42); // i32 automatically widens to i64
+    activation.insert("items", Value::list([1, 2, 3]));
+    activation.insert("config", Value::map([("host", "localhost"), ("port", "8080")]));
+
+    // Extract i64
+    let ast = env.compile("count * 2").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    let value: i64 = (&result).try_into().expect("expected int");
+    println!("i64: {}", value);
+
+    // Extract bool
+    let ast = env.compile("count > 10").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    let value: bool = (&result).try_into().expect("expected bool");
+    println!("bool: {}", value);
+
+    // Extract &str
+    let ast = env.compile("config.host").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    let value: &str = (&result).try_into().expect("expected string");
+    println!("&str: {}", value);
+
+    // Extract &[Value] (list)
+    let ast = env.compile("items.filter(x, x > 1)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    let list: &[Value] = (&result).try_into().expect("expected list");
+    println!("list length: {}", list.len());
+    for (i, v) in list.iter().enumerate() {
+        let n: i64 = v.try_into().expect("expected int");
+        println!("  [{}] = {}", i, n);
+    }
+
+    // Extract &ValueMap
+    let ast = env.compile("config").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    let map: &ValueMap = (&result).try_into().expect("expected map");
+    println!("map size: {}", map.len());
+    for (k, v) in map.iter() {
+        println!("  {:?} = {}", k, v);
+    }
+
+    // Handle errors gracefully
+    let result = Value::from("not an int");
+    let attempt: Result<i64, _> = (&result).try_into();
+    match attempt {
+        Ok(v) => println!("got: {}", v),
+        Err(e) => println!("conversion error: {}", e),
+    }
+
+    // Extract &OptionalValue
+    let opt_result = Value::optional_some(Value::from(99));
+    let opt: &OptionalValue = (&opt_result).try_into().expect("expected optional");
+    if opt.is_present() {
+        let inner: i64 = opt.as_value().unwrap().try_into().expect("expected int");
+        println!("optional value: {}", inner);
+    }
+}

--- a/crates/cel-core/examples/hello.rs
+++ b/crates/cel-core/examples/hello.rs
@@ -1,0 +1,19 @@
+//! Minimal CEL example.
+//!
+//! Run with: cargo run -p cel-core --example hello
+
+use cel_core::eval::MapActivation;
+use cel_core::{CelType, Env};
+
+fn main() {
+    let env = Env::with_standard_library().with_variable("name", CelType::String);
+
+    let ast = env.compile(r#""Hello, " + name + "!""#).unwrap();
+    let program = env.program(&ast).unwrap();
+
+    let mut activation = MapActivation::new();
+    activation.insert("name", "World");
+
+    let result = program.eval(&activation);
+    println!("{}", result);
+}

--- a/crates/cel-core/examples/lists.rs
+++ b/crates/cel-core/examples/lists.rs
@@ -1,0 +1,49 @@
+//! List operations in CEL.
+//!
+//! Run with: cargo run -p cel-core --example lists
+
+use cel_core::eval::{MapActivation, Value};
+use cel_core::{CelType, Env};
+
+fn main() {
+    let env = Env::with_standard_library().with_variable("numbers", CelType::list(CelType::Int));
+
+    let mut activation = MapActivation::new();
+    activation.insert("numbers", Value::list([1, 5, 3, 8, 2]));
+
+    // Filter: keep only values > 3
+    let ast = env.compile("numbers.filter(x, x > 3)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("filter(x, x > 3): {}", result);
+
+    // Map: double each value
+    let ast = env.compile("numbers.map(x, x * 2)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("map(x, x * 2):    {}", result);
+
+    // Exists: any value > 7?
+    let ast = env.compile("numbers.exists(x, x > 7)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("exists(x, x > 7): {}", result);
+
+    // All: all values > 0?
+    let ast = env.compile("numbers.all(x, x > 0)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("all(x, x > 0):    {}", result);
+
+    // Size
+    let ast = env.compile("numbers.size()").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("size():           {}", result);
+
+    // Contains (using 'in' operator)
+    let ast = env.compile("5 in numbers").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("5 in numbers:     {}", result);
+}

--- a/crates/cel-core/examples/maps.rs
+++ b/crates/cel-core/examples/maps.rs
@@ -1,0 +1,53 @@
+//! Map operations in CEL.
+//!
+//! Run with: cargo run -p cel-core --example maps
+
+use cel_core::eval::{MapActivation, Value};
+use cel_core::{CelType, Env};
+
+fn main() {
+    let env =
+        Env::with_standard_library().with_variable("user", CelType::map(CelType::String, CelType::Dyn));
+
+    // Mixed value types require explicit Value::from()
+    let user = Value::map([
+        ("name", Value::from("Alice")),
+        ("age", Value::from(30)), // i32 automatically widens to i64
+        ("active", Value::from(true)),
+    ]);
+
+    let mut activation = MapActivation::new();
+    activation.insert("user", user);
+
+    // Field access
+    let ast = env.compile("user.name").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("user.name:     {}", result);
+
+    // Index access
+    let ast = env.compile(r#"user["age"]"#).unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!(r#"user["age"]:   {}"#, result);
+
+    // Check field existence with 'in'
+    let ast = env.compile(r#""name" in user"#).unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!(r#""name" in user: {}"#, result);
+
+    // Check field existence with has()
+    let ast = env.compile("has(user.email)").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("has(user.email): {}", result);
+
+    // Combine conditions
+    let ast = env
+        .compile(r#"user.active && user.age >= 21"#)
+        .unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+    println!("active && age >= 21: {}", result);
+}

--- a/crates/cel-core/src/eval/evaluator.rs
+++ b/crates/cel-core/src/eval/evaluator.rs
@@ -1311,7 +1311,7 @@ mod tests {
         assert_eq!(eval_expr("42"), Value::Int(42));
         assert_eq!(eval_expr("42u"), Value::UInt(42));
         assert_eq!(eval_expr("3.14"), Value::Double(3.14));
-        assert_eq!(eval_expr("\"hello\""), Value::string("hello"));
+        assert_eq!(eval_expr("\"hello\""), "hello".into());
     }
 
     #[test]
@@ -1358,7 +1358,7 @@ mod tests {
 
     #[test]
     fn test_string_operations() {
-        assert_eq!(eval_expr("\"hello\" + \" world\""), Value::string("hello world"));
+        assert_eq!(eval_expr("\"hello\" + \" world\""), "hello world".into());
         assert_eq!(eval_expr("size(\"hello\")"), Value::Int(5));
         assert_eq!(
             eval_expr("\"hello\".contains(\"ell\")"),
@@ -1407,7 +1407,7 @@ mod tests {
     fn test_type_conversions() {
         assert_eq!(eval_expr("int(3.7)"), Value::Int(3));
         assert_eq!(eval_expr("double(42)"), Value::Double(42.0));
-        assert_eq!(eval_expr("string(42)"), Value::string("42"));
+        assert_eq!(eval_expr("string(42)"), "42".into());
         assert_eq!(eval_expr("int(\"42\")"), Value::Int(42));
     }
 

--- a/crates/cel-core/src/eval/functions.rs
+++ b/crates/cel-core/src/eval/functions.rs
@@ -177,20 +177,6 @@ impl FunctionRegistry {
     }
 }
 
-/// Helper trait for creating function implementations.
-pub trait IntoFunctionImpl {
-    fn into_impl(self) -> FunctionImpl;
-}
-
-impl<F> IntoFunctionImpl for F
-where
-    F: Fn(&[Value]) -> Value + Send + Sync + 'static,
-{
-    fn into_impl(self) -> FunctionImpl {
-        Arc::new(self)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cel-core/src/eval/mod.rs
+++ b/crates/cel-core/src/eval/mod.rs
@@ -41,4 +41,4 @@ pub use error::{EvalError, EvalErrorKind};
 pub use evaluator::Evaluator;
 pub use functions::{Function, FunctionImpl, FunctionRegistry, Overload};
 pub use program::Program;
-pub use value::{Duration, MapKey, OptionalValue, Timestamp, TypeValue, Value, ValueMap};
+pub use value::{Duration, MapKey, OptionalValue, Timestamp, TypeValue, Value, ValueError, ValueMap};

--- a/crates/cel-core/src/lib.rs
+++ b/crates/cel-core/src/lib.rs
@@ -61,7 +61,7 @@ pub use checker::{
 // Re-export from eval module
 pub use eval::{
     Activation, EmptyActivation, EvalError, EvalErrorKind, Evaluator, FunctionRegistry,
-    HierarchicalActivation, MapActivation, Program, Value,
+    HierarchicalActivation, MapActivation, Program, Value, ValueError,
 };
 
 // Re-export from parser module


### PR DESCRIPTION
## Summary

- Add idiomatic Rust `From<T>` and `TryFrom<&Value>` traits for converting between `Value` and native types
- Support integer widening (i8/i16/i32 → i64, u8/u16/u32 → u64) for ergonomic usage
- Add `ValueError` type for handling conversion errors
- Update `MapActivation::insert()` and `HierarchicalActivation` methods to accept `impl Into<Value>`
- Improve `Value::map()` and `Value::list()` constructors to accept generic iterators
- Add examples demonstrating the new API

## Test plan

- [x] All existing tests pass
- [x] New unit tests cover From/TryFrom implementations
- [x] Doc tests verify example code compiles
- [x] Examples can be run with `cargo run -p cel-core --example hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)