### PR TITLE
feat: add abbreviations support for namespace resolution

### DIFF
--- a/CONFORMANCE_FAILURES.md
+++ b/CONFORMANCE_FAILURES.md
@@ -1,0 +1,152 @@
+# CEL Conformance Test Failures Report
+
+**Generated:** 2026-01-27
+**Total Failing Tests:** 841
+
+## Summary by Test File
+
+| Test File | Failures | Notes |
+|-----------|----------|-------|
+| test_basic_eval | 1 | Bytes UTF-8 encoding |
+| test_block_ext | 37 | `cel.block` extension not implemented |
+| test_block_ext_eval | 37 | `cel.block` extension not implemented |
+| test_comparisons_eval | 47 | Various comparison issues |
+| test_conversions_eval | 16 | Bytes/string encoding, int range |
+| test_dynamic_eval | 104 | `google.protobuf.Value` handling |
+| test_encoders_ext_eval | 4 | `base64` namespace not implemented |
+| test_fields_eval | 10 | Proto field access issues |
+| test_lists_eval | 8 | List operation issues |
+| test_logic_eval | 2 | Logic operation issues |
+| test_macros2 | 19 | `cel.bind` macro issues |
+| test_macros2_eval | 22 | `cel.bind` macro issues |
+| test_macros_eval | 2 | Macro issues |
+| test_math_ext_eval | 182 | Many math functions missing |
+| test_namespace_eval | 6 | Namespace resolution issues |
+| test_optionals_eval | 60 | Optional value handling |
+| test_parse_eval | 53 | Parse/escape sequence issues |
+| test_proto2_eval | 41 | Proto2-specific handling |
+| test_proto2_ext | 18 | `proto.hasExt/getExt` not implemented |
+| test_proto2_ext_eval | 18 | `proto.hasExt/getExt` not implemented |
+| test_proto3_eval | 16 | Proto3-specific handling |
+| test_string_eval | 1 | String operation issue |
+| test_string_ext_eval | 84 | Many string functions missing/broken |
+| test_timestamps_eval | 2 | Timestamp handling |
+| test_type_deduction | 5 | Type deduction issues |
+| test_type_deduction_check | 22 | Type checking issues |
+| test_type_deduction_eval | 2 | Type deduction issues |
+| test_wrappers_eval | 22 | Wrapper type handling |
+
+## Categorized by Root Cause
+
+### 1. Missing Extensions (Priority: High)
+
+#### `cel.block` Extension (74 failures)
+- **Files:** test_block_ext, test_block_ext_eval
+- **Issue:** The `cel.block`, `cel.index`, `cel.iterVar` functions are not implemented
+- **Example:** `cel.block([1, cel.index(0) + 1], cel.index(1))`
+
+#### `base64` Namespace (4 failures)
+- **Files:** test_encoders_ext_eval
+- **Issue:** `base64.encode` and `base64.decode` need namespace support (currently only `base64_encode`/`base64_decode`)
+- **Example:** `base64.encode(b'hello')` returns "unknown identifier: base64"
+
+#### `proto.hasExt/getExt` Extension (36 failures)
+- **Files:** test_proto2_ext, test_proto2_ext_eval
+- **Issue:** Proto2 extension field access not implemented
+- **Example:** `proto.hasExt(msg, cel.expr.conformance.proto2.int32_ext)`
+
+#### Missing Math Functions (182 failures)
+- **Files:** test_math_ext_eval
+- **Missing functions:**
+  - `math.ceil`, `math.floor`, `math.round`, `math.trunc`
+  - `math.sign`
+  - `math.isInf`, `math.isNaN`, `math.isFinite`
+  - `math.copysign`
+- **Example:** `math.ceil(1.2)` returns error
+
+### 2. Well-Known Type Handling (Priority: High)
+
+#### `google.protobuf.Value` (75+ failures)
+- **Files:** test_dynamic_eval, test_wrappers_eval
+- **Issue:** Cannot convert CEL values to `google.protobuf.Value` fields
+- **Example:** `TestAllTypes{single_value: 'foo'}` fails with "expected google.protobuf.Value, got string"
+
+#### `google.protobuf.Struct` (failures included above)
+- **Issue:** Cannot convert CEL maps to `google.protobuf.Struct`
+- **Example:** `TestAllTypes{single_struct: {'one': 1}}` fails with "expected google.protobuf.Struct, got map"
+
+#### `google.protobuf.Any` (failures included above)
+- **Issue:** Nested Any encoding is incorrect
+- **Example:** `TestAllTypes{single_any: TestAllTypes{single_int32: 1}}` encodes incorrectly
+
+### 3. Bytes/String Encoding (Priority: Medium)
+
+#### UTF-8 Handling (62 failures)
+- **Files:** test_basic_eval, test_conversions_eval, test_parse_eval
+- **Issues:**
+  - Bytes with values >127 are being UTF-8 encoded when they shouldn't be
+  - `string(bytes)` not validating UTF-8 properly
+  - Escape sequences in strings not handled correctly
+- **Examples:**
+  - `b'\377'` serializes as `[195, 191]` instead of `[255]`
+  - `string(b'\000\xff')` should error but returns a string
+
+### 4. String Extension Functions (Priority: Medium)
+
+#### Missing/Broken Functions (84 failures)
+- **Files:** test_string_ext_eval
+- **Issues:**
+  - `split()` with limit parameter
+  - `replace()` with limit parameter
+  - `substring()` behavior
+  - `trim()` with Unicode whitespace
+  - `format()` function
+  - `quote()` function
+  - `join()` on lists
+
+### 5. Proto Field Behavior (Priority: Medium)
+
+#### `has()` Function (25 failures)
+- **Issues:**
+  - `has(proto.undefined_field)` should error, returns false
+  - `has()` on enum fields set to default value returns false (should be true)
+  - `has()` on oneof fields set to default returns false (should be true)
+
+#### Null/Empty Field Handling (16 failures)
+- **Issues:**
+  - Setting field to null doesn't clear it properly
+  - Empty wrapper types should return null, return 0
+  - Proto equality with null fields
+
+### 6. Optional Value Handling (Priority: Medium)
+
+#### Optional Operations (60 failures)
+- **Files:** test_optionals_eval
+- **Issue:** Various optional value behaviors not matching spec
+
+### 7. Int/Double Range Checking (Priority: Low)
+
+#### Range Errors (5 failures)
+- **Issue:** `int()` conversion from large doubles should error
+- **Example:** `int(1e99)` should error but returns max int64
+
+### 8. Type Checking Issues (Priority: Low)
+
+#### Type Parameter Resolution (27 failures)
+- **Files:** test_type_deduction, test_type_deduction_check
+- **Issue:** Generic type parameter resolution in checker
+- **Example:** `tuple` type not recognized
+
+#### Wrapper Type Promotion (3 failures)
+- **Issue:** Wrapper types not properly assignable
+
+## Recommended Fix Priority
+
+1. **Well-Known Types (Value/Struct/Any)** - Blocks many proto tests
+2. **Bytes Encoding** - Affects proto serialization correctness
+3. **Math Extension** - Large number of failures, relatively easy
+4. **String Extension** - Large number of failures
+5. **cel.block Extension** - Popular optimization extension
+6. **base64 Namespace** - Simple fix (add namespace alias)
+7. **Proto has() Behavior** - Correctness issue
+8. **proto.hasExt/getExt** - Proto2-specific feature

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -613,6 +613,7 @@ let result = program.eval(&[("name", Value::String("test123".into()))])?;
 - [x] Unified `Ast` type with proto roundtrip support
 - [x] AST unparser (to_cel_string)
 - [x] Container support for qualified name resolution
+- [x] Abbreviations support for type name shortcuts
 - [x] Conformance tests: 24/30 files passing
 
 ### Milestone 4: Evaluation

--- a/crates/cel-core-conformance/src/lib.rs
+++ b/crates/cel-core-conformance/src/lib.rs
@@ -155,10 +155,11 @@ pub trait ConformanceService {
     /// # Arguments
     /// * `expr` - The expression to evaluate (either parsed or checked)
     /// * `bindings` - Variable bindings for evaluation
+    /// * `container` - Container namespace for qualified name resolution
     ///
     /// # Returns
     /// An EvalResponse containing the result or issues.
-    fn eval(&self, expr: &ParsedExpr, bindings: &[Binding]) -> EvalResponse;
+    fn eval(&self, expr: &ParsedExpr, bindings: &[Binding], container: &str) -> EvalResponse;
 }
 
 /// A type declaration for a variable in the type environment.

--- a/crates/cel-core-conformance/tests/conformance.rs
+++ b/crates/cel-core-conformance/tests/conformance.rs
@@ -357,7 +357,7 @@ fn run_eval_conformance_file(filename: &str) -> (usize, Vec<EvalTestFailure>) {
             };
 
             // Evaluate - always get a result to compare
-            let eval_result = service.eval(&parsed_expr, &bindings);
+            let eval_result = service.eval(&parsed_expr, &bindings, &test.container);
             let actual_result = match &eval_result.result {
                 Some(r) => r,
                 None => {

--- a/crates/cel-core/Cargo.toml
+++ b/crates/cel-core/Cargo.toml
@@ -14,3 +14,4 @@ logos.workspace = true
 prost-reflect.workspace = true
 prost.workspace = true
 regex.workspace = true
+

--- a/crates/cel-core/examples/namespaces/README.md
+++ b/crates/cel-core/examples/namespaces/README.md
@@ -1,0 +1,104 @@
+# Namespace Resolution for Protobuf Types
+
+CEL provides two mechanisms to simplify working with fully-qualified protobuf type names:
+
+| Feature | Purpose | Protobuf Analogy |
+|---------|---------|------------------|
+| **Container** | Set default package context | `package myapp.models;` |
+| **Abbreviations** | Import specific types | `import "google/protobuf/timestamp.proto";` |
+
+## Name Resolution Order
+
+When cel-core encounters a type name (e.g., `Timestamp` in `Timestamp{seconds: 123}`), it resolves the name in this order:
+
+### 1. Container Hierarchy (C++ Namespace Rules)
+
+If a container is set, cel-core walks up the package hierarchy. For container `a.b.c` and name `Foo`:
+
+```
+a.b.c.Foo  →  a.b.Foo  →  a.Foo  →  Foo
+```
+
+The first match wins. This mirrors how protobuf resolves type references in `.proto` files.
+
+### 2. Abbreviations Map
+
+If no container match is found, cel-core checks the abbreviations map for an explicit short name → fully qualified name mapping.
+
+### 3. Fully Qualified Name
+
+Finally, the name is used as-is (assumed to already be fully qualified).
+
+## Resolution During Compilation vs Evaluation
+
+Name resolution happens at **two stages**:
+
+### Compile Time (Type Checking)
+
+When you call `env.compile("Timestamp{seconds: 123}")`:
+
+1. The checker resolves `Timestamp` using containers/abbreviations
+2. The fully qualified name (`google.protobuf.Timestamp`) is stored in the AST's reference map
+3. Type information is validated against the proto registry
+
+### Evaluation Time
+
+When you call `program.eval(&activation)`:
+
+1. The evaluator first checks the reference map for pre-resolved names from type checking
+2. If not found, it re-applies container/abbreviation resolution
+3. The proto registry constructs the actual message
+
+This two-stage approach means type checking catches errors early, and evaluation uses the pre-resolved names for efficiency.
+
+## Containers
+
+```rust
+let env = Env::with_standard_library()
+    .with_proto_types(registry)
+    .with_container("google.protobuf");
+
+// "Timestamp" resolves to "google.protobuf.Timestamp"
+env.compile("Timestamp{seconds: 123}")
+```
+
+## Abbreviations
+
+```rust
+let abbrevs = Abbreviations::new()
+    .add("google.protobuf.Timestamp")?
+    .add("google.protobuf.Duration")?;
+
+let env = Env::with_standard_library()
+    .with_proto_types(registry)
+    .with_abbreviations(abbrevs);
+
+// "Timestamp" resolves via abbreviation
+env.compile("Timestamp{seconds: 123}")
+```
+
+## Using Both Together
+
+```rust
+let abbrevs = Abbreviations::from_qualified_names(&[
+    "google.protobuf.Timestamp",
+    "google.protobuf.Duration",
+])?;
+
+let env = Env::with_standard_library()
+    .with_proto_types(registry)
+    .with_container("myapp.models")      // Domain types resolve here first
+    .with_abbreviations(abbrevs);        // Well-known types via abbreviation
+```
+
+With this setup:
+- `User` → tries `myapp.models.User` first (container)
+- `Timestamp` → not in `myapp.models`, falls through to abbreviation → `google.protobuf.Timestamp`
+
+## Run the Examples
+
+```bash
+cargo run -p cel-core --example containers
+cargo run -p cel-core --example abbreviations
+cargo run -p cel-core --example combined
+```

--- a/crates/cel-core/examples/namespaces/abbreviations.rs
+++ b/crates/cel-core/examples/namespaces/abbreviations.rs
@@ -1,0 +1,48 @@
+//! Abbreviations let you use short names for fully-qualified protobuf types.
+//!
+//! Run with: cargo run -p cel-core --example abbreviations
+
+use cel_core::eval::{Duration, MapActivation, Timestamp, Value};
+use cel_core::types::ProtoTypeRegistry;
+use cel_core::{Abbreviations, CelType, Env};
+
+fn main() {
+    let registry = ProtoTypeRegistry::new();
+
+    let abbrevs = Abbreviations::new()
+        .add("google.protobuf.Timestamp")
+        .unwrap()
+        .add("google.protobuf.Duration")
+        .unwrap();
+
+    let env = Env::with_standard_library()
+        .with_proto_types(registry)
+        .with_abbreviations(abbrevs)
+        .with_variable("event_time", CelType::Timestamp)
+        .with_variable("timeout", CelType::Duration);
+
+    // Construct proto messages using abbreviated names
+    let ast = env.compile("Timestamp{seconds: 1704067200}").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&MapActivation::new());
+
+    println!("Abbreviations: Timestamp -> google.protobuf.Timestamp");
+    println!("               Duration  -> google.protobuf.Duration\n");
+    println!("Expression: Timestamp{{seconds: 1704067200}}");
+    println!("Result: {}\n", result);
+
+    // Calculate deadline: event_time + timeout
+    let ast = env.compile("event_time + timeout").unwrap();
+    let program = env.program(&ast).unwrap();
+
+    let mut activation = MapActivation::new();
+    activation.insert("event_time", Value::Timestamp(Timestamp::from_seconds(1704110400)));
+    activation.insert("timeout", Value::Duration(Duration::from_seconds(1800)));
+
+    let result = program.eval(&activation);
+
+    println!("Expression: event_time + timeout");
+    println!("  event_time = 2024-01-01 12:00:00 UTC");
+    println!("  timeout = 30 minutes");
+    println!("Result: {}", result);
+}

--- a/crates/cel-core/examples/namespaces/combined.rs
+++ b/crates/cel-core/examples/namespaces/combined.rs
@@ -1,0 +1,65 @@
+//! Using containers and abbreviations together.
+//!
+//! Run with: cargo run -p cel-core --example combined
+
+use cel_core::eval::{Duration, MapActivation, Timestamp, Value};
+use cel_core::types::ProtoTypeRegistry;
+use cel_core::{Abbreviations, CelType, Env};
+
+fn main() {
+    let registry = ProtoTypeRegistry::new();
+
+    // Container for our domain, abbreviations for well-known types
+    let abbrevs = Abbreviations::from_qualified_names(&[
+        "google.protobuf.Timestamp",
+        "google.protobuf.Duration",
+    ])
+    .unwrap();
+
+    let env = Env::with_standard_library()
+        .with_proto_types(registry)
+        .with_container("myapp.models")
+        .with_abbreviations(abbrevs)
+        .with_variable("request_time", CelType::Timestamp)
+        .with_variable("max_age", CelType::Duration)
+        .with_variable("now", CelType::Timestamp);
+
+    println!("Container: myapp.models");
+    println!("Abbreviations: Timestamp, Duration\n");
+
+    // Construct proto message with abbreviated type name
+    let ast = env.compile("Timestamp{seconds: 1704067200, nanos: 0}").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&MapActivation::new());
+
+    println!("Proto construction with abbreviation:");
+    println!("  Timestamp{{seconds: 1704067200, nanos: 0}}");
+    println!("  Result: {}\n", result);
+
+    // Check if cache is still valid using CEL timestamp arithmetic
+    let ast = env.compile("now < request_time + max_age").unwrap();
+    let program = env.program(&ast).unwrap();
+
+    let mut activation = MapActivation::new();
+    activation.insert("request_time", Value::Timestamp(Timestamp::from_seconds(1704110400)));
+    activation.insert("max_age", Value::Duration(Duration::from_seconds(3600)));
+    activation.insert("now", Value::Timestamp(Timestamp::from_seconds(1704112200)));
+
+    let result = program.eval(&activation);
+
+    println!("Cache validity check:");
+    println!("  Expression: now < request_time + max_age");
+    println!("  request_time = 2024-01-01 12:00:00 UTC");
+    println!("  max_age = 1 hour");
+    println!("  now = 2024-01-01 12:30:00 UTC");
+    println!("  Result: {} (cache still valid)\n", result);
+
+    // Calculate remaining time
+    let ast = env.compile("request_time + max_age - now").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&activation);
+
+    println!("Time remaining:");
+    println!("  Expression: request_time + max_age - now");
+    println!("  Result: {}", result);
+}

--- a/crates/cel-core/examples/namespaces/containers.rs
+++ b/crates/cel-core/examples/namespaces/containers.rs
@@ -1,0 +1,38 @@
+//! Containers set your default protobuf package for type resolution.
+//!
+//! Run with: cargo run -p cel-core --example containers
+
+use cel_core::eval::MapActivation;
+use cel_core::types::ProtoTypeRegistry;
+use cel_core::Env;
+
+fn main() {
+    let registry = ProtoTypeRegistry::new();
+
+    // With container "google.protobuf", we can use short type names
+    let env = Env::with_standard_library()
+        .with_proto_types(registry)
+        .with_container("google.protobuf");
+
+    // Construct a Timestamp using short name (instead of google.protobuf.Timestamp)
+    let ast = env.compile("Timestamp{seconds: 1704067200}").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&MapActivation::new());
+
+    println!("Container: google.protobuf\n");
+    println!("Expression: Timestamp{{seconds: 1704067200}}");
+    println!("Result: {}\n", result);
+
+    // Construct a Duration
+    let ast = env.compile("Duration{seconds: 3600}").unwrap();
+    let program = env.program(&ast).unwrap();
+    let result = program.eval(&MapActivation::new());
+
+    println!("Expression: Duration{{seconds: 3600}}");
+    println!("Result: {}\n", result);
+
+    // Without container, would need: google.protobuf.Timestamp{seconds: ...}
+    println!("Without container, you'd write:");
+    println!("  google.protobuf.Timestamp{{seconds: 1704067200}}");
+    println!("  google.protobuf.Duration{{seconds: 3600}}");
+}

--- a/crates/cel-core/src/checker/mod.rs
+++ b/crates/cel-core/src/checker/mod.rs
@@ -13,6 +13,9 @@ mod overload;
 mod scope;
 mod standard_library;
 
-pub use checker::{check, check_with_proto_types, CheckResult, Checker, ReferenceInfo};
+pub use checker::{
+    check, check_with_abbreviations, check_with_proto_types,
+    check_with_proto_types_and_abbreviations, CheckResult, Checker, ReferenceInfo,
+};
 pub use errors::{CheckError, CheckErrorKind};
 pub use standard_library::STANDARD_LIBRARY;

--- a/crates/cel-core/src/eval/mod.rs
+++ b/crates/cel-core/src/eval/mod.rs
@@ -42,4 +42,4 @@ pub use error::{EvalError, EvalErrorKind};
 pub use evaluator::Evaluator;
 pub use functions::{Function, FunctionImpl, FunctionRegistry, Overload};
 pub use program::Program;
-pub use value::{Duration, MapKey, OptionalValue, Timestamp, TypeValue, Value, ValueError, ValueMap};
+pub use value::{Duration, MapKey, OptionalValue, ProtoValue, Timestamp, TypeValue, Value, ValueError, ValueMap};

--- a/crates/cel-core/src/lib.rs
+++ b/crates/cel-core/src/lib.rs
@@ -50,7 +50,7 @@ pub mod parser;
 pub mod types;
 
 pub use ast::{Ast, AstError};
-pub use env::{CompileError, Env};
+pub use env::{AbbrevError, Abbreviations, CompileError, Env};
 pub use unparser::ast_to_string;
 
 // Re-export from checker module


### PR DESCRIPTION
## Summary
Implements abbreviations support for namespace resolution in CEL expressions, completing Milestone 3 features from the roadmap.

Abbreviations allow short names (like `Timestamp`) to be used instead of fully-qualified names (like `google.protobuf.Timestamp`) in CEL expressions. This complements the existing container support, following cel-go's namespace resolution patterns.

## Changes
- Add `Abbreviations` type in `env.rs` for mapping short names to fully-qualified names
- Integrate abbreviation expansion into the type checker for compile-time resolution
- Integrate abbreviation support into the evaluator for runtime type resolution
- Add namespace examples demonstrating containers, abbreviations, and combined usage
- Update ROADMAP.md to mark abbreviations as complete
- Add CONFORMANCE_FAILURES.md documenting remaining conformance test issues

## Testing
- All unit tests pass (`mise run test`)
- Conformance tests at 29/59 passing (no regression from baseline)
- Manual testing with namespace examples

## Roadmap
See ROADMAP.md section 3 (Milestone 3: Unified Env + Extensions) for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)