### PR TITLE
feat: improve type checker inference for conformance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -725,11 +725,16 @@ Fix variable and namespace resolution edge cases.
 
 Improve type parameter resolution and reduce unnecessary `dyn` fallback.
 
+- [x] Scoped type parameter resolution (prevent cross-expression type param collision)
+- [x] Type parameter binding widening (Null/Dyn/TypeVar widen to concrete types)
+- [x] Null assignability to message/duration/timestamp/optional/abstract parameter types
+- [x] Custom function type declarations (`fn`, `tuple`, `sort` in conformance tests)
+- [x] Comprehension accumulator type refinement from loop step
+- [x] Type specificity-based join_types (prefer concrete types over Dyn)
+- [x] Abstract type matching in overload resolution
+- [x] `optional_type` proto name for Optional type conversion
 - [ ] Parameterized type propagation through nested generics (`list<list<list<T>>>`)
-- [ ] Optional type narrowing (`optional<dyn>` → `optional_type<int>`)
 - [ ] Wrapper type promotion in type checker (`int` → `wrapper<int>`)
-- [ ] Null assignability to message/duration/timestamp/abstract parameter types
-- [ ] Custom function type declarations (`fn`, `tuple`, `sort` in conformance tests)
 
 #### 5.9 Proto Extensions (`proto.hasExt`/`getExt`) (~36 failures)
 

--- a/crates/cel-core-conformance/src/lib.rs
+++ b/crates/cel-core-conformance/src/lib.rs
@@ -148,7 +148,7 @@ pub trait ConformanceService {
     ///
     /// # Returns
     /// A CheckResponse containing the checked expression or issues.
-    fn check(&self, parsed: &ParsedExpr, type_env: &[TypeDecl], container: &str) -> CheckResponse;
+    fn check(&self, parsed: &ParsedExpr, type_env: &[TypeDecl], func_decls: &[FunctionTypeDecl], container: &str) -> CheckResponse;
 
     /// Evaluate an expression with the given bindings.
     ///
@@ -160,7 +160,7 @@ pub trait ConformanceService {
     ///
     /// # Returns
     /// An EvalResponse containing the result or issues.
-    fn eval(&self, expr: &ParsedExpr, bindings: &[Binding], type_env: &[TypeDecl], container: &str) -> EvalResponse;
+    fn eval(&self, expr: &ParsedExpr, bindings: &[Binding], type_env: &[TypeDecl], func_decls: &[FunctionTypeDecl], container: &str) -> EvalResponse;
 }
 
 /// A type declaration for a variable in the type environment.
@@ -170,6 +170,15 @@ pub struct TypeDecl {
     pub name: String,
     /// The CEL type (using proto Type message).
     pub cel_type: cel_core_proto::gen::cel::expr::Type,
+}
+
+/// A function declaration for the type environment.
+#[derive(Debug, Clone)]
+pub struct FunctionTypeDecl {
+    /// The function name.
+    pub name: String,
+    /// The function's overloads (proto format).
+    pub overloads: Vec<cel_core_proto::gen::cel::expr::decl::function_decl::Overload>,
 }
 
 /// A variable binding for evaluation.

--- a/crates/cel-core-proto/src/type_conversion.rs
+++ b/crates/cel-core-proto/src/type_conversion.rs
@@ -121,7 +121,7 @@ pub fn cel_type_from_proto(proto: &ProtoType) -> CelType {
         Some(ProtoTypeKind::Error(_)) => CelType::Error,
         Some(ProtoTypeKind::AbstractType(abs)) => {
             // Special case: "optional" abstract type maps to CelType::Optional
-            if abs.name == "optional" && abs.parameter_types.len() == 1 {
+            if (abs.name == "optional_type" || abs.name == "optional") && abs.parameter_types.len() == 1 {
                 let inner = cel_type_from_proto(&abs.parameter_types[0]);
                 return CelType::Optional(Arc::new(inner));
             }
@@ -186,9 +186,9 @@ pub fn cel_type_to_proto(cel_type: &CelType) -> ProtoType {
             };
             ProtoTypeKind::Wrapper(prim)
         }
-        // Optional is represented as an abstract type "optional" with a type parameter
+        // Optional is represented as an abstract type "optional_type" with a type parameter
         CelType::Optional(inner) => ProtoTypeKind::AbstractType(ProtoAbstractType {
-            name: "optional".to_string(),
+            name: "optional_type".to_string(),
             parameter_types: vec![cel_type_to_proto(inner)],
         }),
         CelType::Error => ProtoTypeKind::Error(()),

--- a/crates/cel-core/src/types/mod.rs
+++ b/crates/cel-core/src/types/mod.rs
@@ -333,8 +333,13 @@ impl CelType {
                 self_key.is_assignable_from(other_key) && self_val.is_assignable_from(other_val)
             }
 
-            // Null is assignable to wrapper types
+            // Null is assignable to wrapper, message, duration, timestamp, optional, abstract types
             (CelType::Wrapper(_), CelType::Null) => true,
+            (CelType::Message(_), CelType::Null) => true,
+            (CelType::Timestamp, CelType::Null) => true,
+            (CelType::Duration, CelType::Null) => true,
+            (CelType::Optional(_), CelType::Null) => true,
+            (CelType::Abstract { .. }, CelType::Null) => true,
             // Wrapper accepts its underlying type (boxing)
             (CelType::Wrapper(inner), other) => inner.is_assignable_from(other),
             // Underlying type accepts Wrapper (unboxing)


### PR DESCRIPTION
## Summary
Implements improvements from section 5.8 (Type Checker Inference Improvements) of the CEL implementation roadmap.

Overhauls overload resolution to use scoped type parameters, expands null assignability across the type system, and adds custom function declaration support to conformance tests. The `type_deduction.textproto` conformance suite now passes fully (47/47 parse+check, 47/47 type_check).

## Changes
- Scoped type parameter resolution in overload matching — each overload attempt gets uniquely-scoped type param names to prevent cross-expression collision
- Type parameter binding widening — bindings to Null/Dyn/TypeVar are replaced by more specific concrete types
- Null assignability expanded to Message, Timestamp, Duration, Optional, and Abstract types
- Custom function type declarations (`FunctionTypeDecl`) plumbed through conformance service
- Comprehension accumulator type refinement from loop step (fixes `map` macro type inference)
- Type specificity-based `join_types` — prefers most specific type instead of first type
- Abstract type matching in overload resolution
- `optional_type` proto name fix for Optional wire format compatibility with cel-go

## Testing
- All unit/integration tests pass (`mise run test`)
- Conformance test results:

| Test Type | Passed | Total | Pass Rate | vs Main |
|-----------|--------|-------|-----------|---------|
| Parse+Check | 1908 | 1927 | 99.0% | +5 |
| Type Check | 47 | 47 | 100.0% | +22 |
| Eval | 2154 | 2186 | 98.5% | +1 |
| **Overall** | **4109** | **4160** | **98.8%** | **+28** |

Key improvement: `type_deduction.textproto` goes from 42/47 parse+check and 25/47 type_check on main to 47/47 on both.

## Roadmap
See ROADMAP.md section 5.8 for full context.