### PR TITLE
feat: walk file tree to discover settings.toml

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -1,28 +1,32 @@
 # Roadmap Handoff
 
 ## Last Updated
-2026-02-14
+2026-02-15
 
 ## Just Completed
-- GitHub Issue: #66 — Show variable types on hover
-- [x] Updated `hover_for_node` and `hover_at_position` to accept `Option<&CheckResult>` instead of `&[CheckError]`
-- [x] Added variable type hover for `Ident` and `RootIdent` nodes via `CheckResult.type_map`
-- [x] Threaded check result through proto hover path (`hover_at_position_proto`)
-- [x] Added tests for variable type hover (int variable, message type)
+- GitHub Issue: #65 — Walk file tree to discover settings.toml
+- [x] Added `discover_settings()` that walks up the directory tree, then checks child directories
+- [x] Updated `DocumentStore::open()` to accept an optional `Env` for `.cel` files
+- [x] Added `env: OnceLock<Arc<Env>>` to `Backend` so settings-configured env is used for all documents
+- [x] Updated `initialize()` to use `discover_settings` instead of `load_settings_from_workspace`
+- [x] Added 5 unit tests for discovery and 1 integration test for end-to-end `.cel` file settings
 
 ### Summary
-Hovering over variables in CEL expressions now shows their declared type (e.g., `(variable) x: int`). The type information was already available in `CheckResult.type_map` — this change threads the full `CheckResult` to the hover functions and looks up identifier nodes by their AST node ID. Works for both standalone `.cel` files and embedded CEL in `.proto` files.
+Previously, settings.toml was only looked for in the workspace root, and even when found, its configuration was only applied to `.proto` files — `.cel` files always got a hardcoded default env. Now the LSP walks up the directory tree from the workspace root to find settings.toml (with a fallback to check immediate child directories), and the discovered settings are applied to both `.cel` and `.proto` files.
 
 ### Key files
-- **Modified:** `crates/cel-core-lsp/src/lsp/hover.rs` — signature changes, variable type hover logic, new tests
-- **Modified:** `crates/cel-core-lsp/src/lib.rs` — pass `check_result.as_ref()` instead of `check_errors()`
+- **Modified:** `crates/cel-core-lsp/src/settings.rs` — added `discover_settings()`, removed unused `load_settings_from_workspace()`, added 5 unit tests
+- **Modified:** `crates/cel-core-lsp/src/document/state.rs` — `DocumentStore::open()` now accepts `env: Option<&Arc<Env>>`
+- **Modified:** `crates/cel-core-lsp/src/lib.rs` — added `env` field to `Backend`, updated `initialize()` and `on_document_change()`
+- **Modified:** `crates/cel-core-lsp/tests/integration.rs` — added `discover_settings_applies_to_cel_files` test
 
 ### Notable decisions
-- Variable hover displays as `` (variable) `name`: `type` `` using markdown inline code for readability
-- Check errors take priority over variable type display (undeclared reference error shown instead of type)
-- Variable type hover is inserted between error check and builtin docs fallback in the priority chain
+- Two-phase search: walk up first (prioritizes parent directories), then check immediate children as fallback
+- Returns `(Settings, PathBuf)` where the PathBuf is the settings directory, used for resolving relative descriptor paths
+- Removed `load_settings_from_workspace` as dead code — fully replaced by `discover_settings`
 
 ## Previous Work
+- GitHub Issue: #66 — Show variable types on hover
 - GitHub Issue: #48 — Move proto value conversion logic from conformance layer to cel-core-proto
 - GitHub Issue: #58 — Macro calls with wrong argument count produce misleading 'undeclared reference' error
 - GitHub Issue: #60 — Automate releases with GitHub Actions
@@ -31,10 +35,10 @@ Hovering over variables in CEL expressions now shows their declared type (e.g., 
 - GitHub Issue: #50 — Decoupled prost/prost-reflect from cel-core via trait abstraction
 
 ## Next Up
-- GitHub Issue: #65 — Walk file tree to discover settings.toml
-  - Settings discovery enhanced to walk up directory tree
-- GitHub Issue: #38 — Richer hover information using CheckResult.type_map
-  - Now partially addressed by #66; remaining work could include showing function return types, expression types, etc.
+- GitHub Issue: #56 — Auto-discover buf dependencies for LSP proto registry
+  - Natural follow-up: now that settings discovery walks the tree, auto-discovering buf.yaml dependencies would reduce manual descriptor configuration
+- GitHub Issue: #44 — LSP workspace/configuration support
+  - Could build on discover_settings to support dynamic workspace configuration changes
 
 ## Open Questions
 - The overload resolution sometimes selects the wrong overload for `(UInt, Int)` args in bit shift functions — it picks `int_int` instead of `uint_int`. Worked around by handling both type combos in the first overload, but root cause may need investigation.

--- a/crates/cel-core-lsp/src/document/state.rs
+++ b/crates/cel-core-lsp/src/document/state.rs
@@ -147,15 +147,24 @@ impl DocumentStore {
 
     /// Open or update a document with the given source text.
     /// Auto-detects document type based on file extension.
+    ///
+    /// If `env` is provided, `.cel` files will use it instead of the default environment.
     pub fn open(
         &self,
         uri: Url,
         source: String,
         version: i32,
         proto_registry: Option<&Arc<ProstProtoRegistry>>,
+        env: Option<&Arc<Env>>,
     ) -> Arc<DocumentKind> {
         let kind = if is_proto_file(&uri) {
             DocumentKind::Proto(ProtoDocumentState::new(source, version, proto_registry))
+        } else if let Some(env) = env {
+            DocumentKind::Cel(Box::new(DocumentState::with_env(
+                source,
+                version,
+                Arc::clone(env),
+            )))
         } else {
             DocumentKind::Cel(Box::new(DocumentState::new(source, version)))
         };

--- a/crates/cel-core-lsp/src/lib.rs
+++ b/crates/cel-core-lsp/src/lib.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
+use cel_core::Env;
 use cel_core_proto::ProstProtoRegistry;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -16,7 +17,7 @@ pub(crate) mod types;
 
 pub use document::{DocumentState, LineIndex, ProtoDocumentState};
 pub use lsp::{completion_at_position_proto, proto_to_diagnostics, to_diagnostics};
-pub use settings::{build_env_with_protos, load_proto_registry, load_settings};
+pub use settings::{build_env_with_protos, discover_settings, load_proto_registry, load_settings};
 
 use document::{DocumentKind, DocumentStore};
 
@@ -25,6 +26,7 @@ pub struct Backend {
     documents: DocumentStore,
     workspace_root: OnceLock<PathBuf>,
     proto_registry: OnceLock<Option<Arc<ProstProtoRegistry>>>,
+    env: OnceLock<Arc<Env>>,
 }
 
 impl Backend {
@@ -34,15 +36,17 @@ impl Backend {
             documents: DocumentStore::new(),
             workspace_root: OnceLock::new(),
             proto_registry: OnceLock::new(),
+            env: OnceLock::new(),
         }
     }
 
     /// Parse document and publish diagnostics.
     async fn on_document_change(&self, uri: Url, text: String, version: i32) {
         let registry = self.proto_registry.get().and_then(|r| r.clone());
+        let env = self.env.get();
         let state = self
             .documents
-            .open(uri.clone(), text, version, registry.as_ref());
+            .open(uri.clone(), text, version, registry.as_ref(), env);
         self.publish_diagnostics_for(&uri, &state).await;
     }
 
@@ -86,10 +90,12 @@ impl LanguageServer for Backend {
         if let Some(root) = workspace_root {
             let _ = self.workspace_root.set(root.clone());
 
-            // Load settings and proto registry
-            let settings = settings::load_settings_from_workspace(&root);
-            let registry = settings::load_proto_registry(&settings, &root);
+            // Discover settings by walking up the directory tree
+            let (settings, settings_dir) = settings::discover_settings(&root);
+            let registry = settings::load_proto_registry(&settings, &settings_dir);
+            let env = Arc::new(settings::build_env_with_protos(&settings, &settings_dir));
             let _ = self.proto_registry.set(registry);
+            let _ = self.env.set(env);
         } else {
             let _ = self.proto_registry.set(None);
         }

--- a/crates/cel-core-lsp/src/settings.rs
+++ b/crates/cel-core-lsp/src/settings.rs
@@ -169,11 +169,39 @@ pub fn load_settings(path: &Path) -> Settings {
     }
 }
 
-/// Load settings from a workspace root directory.
+/// Discover settings.toml by searching up the directory tree, then direct children.
 ///
-/// Looks for settings.toml in the given directory.
-pub fn load_settings_from_workspace(workspace_root: &Path) -> Settings {
-    load_settings(&workspace_root.join("settings.toml"))
+/// Search order:
+/// 1. Walk up from `start_dir` to filesystem root
+/// 2. If not found, check immediate child directories of `start_dir`
+///
+/// Returns `(settings, settings_dir)` where `settings_dir` is the directory
+/// containing the found settings.toml (used for resolving relative paths).
+/// If not found, returns `(Settings::default(), start_dir)`.
+pub fn discover_settings(start_dir: &Path) -> (Settings, PathBuf) {
+    // Phase 1: Walk up from start_dir
+    let mut current = Some(start_dir);
+    while let Some(dir) = current {
+        let candidate = dir.join("settings.toml");
+        if candidate.is_file() {
+            return (load_settings(&candidate), dir.to_path_buf());
+        }
+        current = dir.parent();
+    }
+
+    // Phase 2: Check immediate child directories
+    if let Ok(entries) = std::fs::read_dir(start_dir) {
+        for entry in entries.flatten() {
+            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                let candidate = entry.path().join("settings.toml");
+                if candidate.is_file() {
+                    return (load_settings(&candidate), entry.path());
+                }
+            }
+        }
+    }
+
+    (Settings::default(), start_dir.to_path_buf())
 }
 
 /// Load proto registry from file descriptor set files specified in settings.
@@ -648,5 +676,118 @@ mod tests {
         let env = build_env_with_protos(&settings, std::path::Path::new("."));
         // Env should have standard library functions
         assert!(env.functions().contains_key("size"));
+    }
+
+    /// Create a unique temp directory for test isolation.
+    fn make_test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("cel-core-lsp-test")
+            .join(name)
+            .join(format!("{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Clean up a test directory.
+    fn cleanup_test_dir(dir: &Path) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn discover_settings_in_current_dir() {
+        let dir = make_test_dir("discover-current");
+        let settings_content = r#"
+[env]
+variables = { x = "int" }
+"#;
+        std::fs::write(dir.join("settings.toml"), settings_content).unwrap();
+
+        let (settings, settings_dir) = discover_settings(&dir);
+        assert_eq!(settings_dir, dir);
+        assert!(settings.env.is_some());
+        let vars = settings.env.unwrap().variables.unwrap();
+        assert_eq!(vars.get("x").unwrap(), "int");
+
+        cleanup_test_dir(&dir);
+    }
+
+    #[test]
+    fn discover_settings_in_parent_dir() {
+        let parent = make_test_dir("discover-parent");
+        let child = parent.join("subdir");
+        std::fs::create_dir_all(&child).unwrap();
+
+        let settings_content = r#"
+[env]
+variables = { name = "string" }
+"#;
+        std::fs::write(parent.join("settings.toml"), settings_content).unwrap();
+
+        let (settings, settings_dir) = discover_settings(&child);
+        assert_eq!(settings_dir, parent);
+        assert!(settings.env.is_some());
+        let vars = settings.env.unwrap().variables.unwrap();
+        assert_eq!(vars.get("name").unwrap(), "string");
+
+        cleanup_test_dir(&parent);
+    }
+
+    #[test]
+    fn discover_settings_in_child_dir() {
+        let parent = make_test_dir("discover-child");
+        let child = parent.join("config");
+        std::fs::create_dir_all(&child).unwrap();
+
+        let settings_content = r#"
+[env]
+extensions = ["strings"]
+"#;
+        std::fs::write(child.join("settings.toml"), settings_content).unwrap();
+
+        let (settings, settings_dir) = discover_settings(&parent);
+        assert_eq!(settings_dir, child);
+        assert!(settings.env.is_some());
+        let exts = settings.env.unwrap().extensions.unwrap();
+        assert_eq!(exts, vec!["strings"]);
+
+        cleanup_test_dir(&parent);
+    }
+
+    #[test]
+    fn discover_settings_not_found() {
+        let dir = make_test_dir("discover-none");
+
+        let (settings, settings_dir) = discover_settings(&dir);
+        assert_eq!(settings_dir, dir);
+        assert!(settings.env.is_none());
+
+        cleanup_test_dir(&dir);
+    }
+
+    #[test]
+    fn discover_settings_parent_preferred_over_child() {
+        let parent = make_test_dir("discover-priority");
+        let child = parent.join("nested");
+        std::fs::create_dir_all(&child).unwrap();
+
+        // Put settings in both parent and child
+        std::fs::write(
+            parent.join("settings.toml"),
+            "[env]\nvariables = { from = \"string\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            child.join("settings.toml"),
+            "[env]\nvariables = { from = \"int\" }\n",
+        )
+        .unwrap();
+
+        // When starting from parent, should find parent's settings (phase 1) before checking children
+        let (settings, settings_dir) = discover_settings(&parent);
+        assert_eq!(settings_dir, parent);
+        let vars = settings.env.unwrap().variables.unwrap();
+        assert_eq!(vars.get("from").unwrap(), "string");
+
+        cleanup_test_dir(&parent);
     }
 }

--- a/crates/cel-core-lsp/tests/integration.rs
+++ b/crates/cel-core-lsp/tests/integration.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use cel_core::Env;
-use cel_core_lsp::{build_env_with_protos, load_proto_registry, load_settings};
+use cel_core_lsp::{build_env_with_protos, discover_settings, load_proto_registry, load_settings};
 use cel_core_lsp::{
     completion_at_position_proto, proto_to_diagnostics, to_diagnostics, DocumentState, LineIndex,
     ProtoDocumentState,
@@ -448,4 +448,36 @@ fn proto_completion_int_field_no_string_methods() {
         "should NOT suggest contains for int field: {:?}",
         labels
     );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — settings discovery
+// ---------------------------------------------------------------------------
+
+/// Use discover_settings from a subdirectory to find settings in the fixtures
+/// parent, then verify .cel files get the configured variables.
+#[test]
+fn discover_settings_applies_to_cel_files() {
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/basic");
+
+    // Simulate discovering settings from a child directory
+    let child = fixture_path.join("subdir");
+    std::fs::create_dir_all(&child).ok();
+
+    let (settings, settings_dir) = discover_settings(&child);
+    assert_eq!(settings_dir, fixture_path);
+
+    let env = Arc::new(build_env_with_protos(&settings, &settings_dir));
+
+    // CEL expression using variables declared in basic/settings.toml should work
+    let state = DocumentState::with_env("x > 10 && name.startsWith('test')".to_string(), 0, env);
+    let line_index = LineIndex::new(state.source.clone());
+    let diagnostics = to_diagnostics(&state.errors, state.check_errors(), &line_index);
+    let actual = format_diagnostics(&diagnostics);
+
+    let expected = expect![[r#"OK (no diagnostics)"#]];
+    expected.assert_eq(&actual);
+
+    // Clean up temp dir
+    let _ = std::fs::remove_dir(&child);
 }


### PR DESCRIPTION
## Summary
Closes #65

The LSP now discovers `settings.toml` by walking up the directory tree from the workspace root, with a fallback to check immediate child directories. Additionally, discovered settings are now applied to both `.cel` and `.proto` files — previously `.cel` files always used a hardcoded default environment.

## Changes
- Added `discover_settings()` function with two-phase search: walk up parent directories, then check immediate children
- Updated `DocumentStore::open()` to accept an optional `Env` for `.cel` files
- Added `env: OnceLock<Arc<Env>>` to `Backend` so the settings-configured environment is stored and passed to all document opens
- Replaced `load_settings_from_workspace()` call in `initialize()` with `discover_settings()`
- Removed unused `load_settings_from_workspace()` function

## Testing
- 5 unit tests for `discover_settings`: current dir, parent dir, child dir, not found, parent-preferred-over-child
- 1 integration test verifying `.cel` files get settings-configured variables via discovery
- All existing tests pass
- Conformance test results:

| Test Type | Passed | Total | Pass Rate | vs Baseline |
|-----------|--------|-------|-----------|-------------|
| Parse+Check | 2365 | 2365 | 100.0% | +0 |
| Type Check | 47 | 47 | 100.0% | +0 |
| Eval | 2340 | 2340 | 100.0% | +0 |
| **Overall** | **4752** | **4752** | **100.0%** | **+0** |